### PR TITLE
Ajoute endpoint pour anime récents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle build -i --stacktrace
 
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 EXPOSE 9000
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.0")
-	implementation("net.sandrohc:reactive-jikan:2.2.0")
+	implementation("net.sandrohc:reactive-jikan:2.3.0-SNAPSHOT")
 	implementation("com.github.zakaoai:NyaaSi-API:1.0.2")
 
 	// https://mvnrepository.com/artifact/org.springframework.session/spring-session-core

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,101 +1,103 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.2.2"
-	id("io.spring.dependency-management") version "1.1.4"
-	kotlin("jvm") version "1.9.21"
-	kotlin("plugin.spring") version "1.9.21"
-	id("org.springdoc.openapi-gradle-plugin") version "1.8.0"
-	id ("jacoco")
+    id("org.springframework.boot") version "3.2.2"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "1.9.21"
+    kotlin("plugin.spring") version "1.9.21"
+    id("org.springdoc.openapi-gradle-plugin") version "1.8.0"
+    id("jacoco")
 }
 
 group = "fr.zakaoai"
 version = "2.0.0-SNAPSHOT"
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
-	jvmToolchain(17)
+    jvmToolchain(17)
 }
 
 
 repositories {
-	mavenCentral()
-	maven {
-		url = uri("https://jcenter.bintray.com")
-	}
-	maven {
-		url = uri("https://jitpack.io")
-	}
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = uri("https://jcenter.bintray.com")
+    }
+    maven {
+        url = uri("https://jitpack.io")
+    }
 
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 // https://mvnrepository.com/artifact/org.springframework.security/spring-security-oauth2-resource-server
-	implementation("org.springframework.security:spring-security-oauth2-resource-server")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-	implementation("org.springframework.boot:spring-boot-starter-cache")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-	implementation("org.liquibase:liquibase-core")
-	implementation("org.springframework:spring-jdbc")
-	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
+    implementation("org.springframework.security:spring-security-oauth2-resource-server")
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+    implementation("org.liquibase:liquibase-core")
+    implementation("org.springframework:spring-jdbc")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
 // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-api
-	testImplementation("org.springdoc:springdoc-openapi-starter-webflux-api:2.3.0")
-	runtimeOnly("org.postgresql:postgresql")
-	runtimeOnly("org.postgresql:r2dbc-postgresql")
-	testImplementation("org.springframework.boot:spring-boot-starter-test") {
-		exclude(module = "mockito-core")
-	}
-	testImplementation("io.projectreactor:reactor-test")
-	testImplementation("org.springframework.security:spring-security-test")
-	// https://mvnrepository.com/artifact/io.mockk/mockk
-	testImplementation("io.mockk:mockk:1.13.8")
-	testImplementation("com.ninja-squad:springmockk:4.0.2")
-	testImplementation ("io.rest-assured:spring-mock-mvc")
-	// https://mvnrepository.com/artifact/io.rest-assured/spring-mock-mvc-kotlin-extensions
-	testImplementation("io.rest-assured:spring-mock-mvc-kotlin-extensions")
+    testImplementation("org.springdoc:springdoc-openapi-starter-webflux-api:2.3.0")
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.postgresql:r2dbc-postgresql")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(module = "mockito-core")
+    }
+    testImplementation("io.projectreactor:reactor-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    // https://mvnrepository.com/artifact/io.mockk/mockk
+    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("io.rest-assured:spring-mock-mvc")
+    // https://mvnrepository.com/artifact/io.rest-assured/spring-mock-mvc-kotlin-extensions
+    testImplementation("io.rest-assured:spring-mock-mvc-kotlin-extensions")
 
-	// https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.0")
-	implementation("net.sandrohc:reactive-jikan:2.3.0-SNAPSHOT")
-	implementation("com.github.zakaoai:NyaaSi-API:1.0.2")
+    // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.0")
+    implementation("com.github.zakaoai:reactive-jikan:feature~pagination-SNAPSHOT")
 
-	// https://mvnrepository.com/artifact/org.springframework.session/spring-session-core
-	implementation("org.springframework.session:spring-session-core")
+    implementation("com.github.zakaoai:NyaaSi-API:1.0.2")
 
-	implementation("com.auth0:auth0:2.10.0")
+    // https://mvnrepository.com/artifact/org.springframework.session/spring-session-core
+    implementation("org.springframework.session:spring-session-core")
+
+    implementation("com.auth0:auth0:2.10.0")
 
 
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		freeCompilerArgs += "-Xjsr305=strict"
-		jvmTarget = "17"
-	}
+    kotlinOptions {
+        freeCompilerArgs += "-Xjsr305=strict"
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.jacocoTestReport {
-	reports {
-		xml.required.set(true)
-	}
-	dependsOn(tasks.test) // tests are required to run before generating the report
+    reports {
+        xml.required.set(true)
+    }
+    dependsOn(tasks.test) // tests are required to run before generating the report
 }
 
 tasks.jar {
-	enabled = false
+    enabled = false
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
@@ -29,6 +29,7 @@ class RouterConfiguration {
             }
             "/anime".nest {
                 GET("", animeHandler::getAllAnime)
+                GET("recent",animeHandler::getRecent)
                 GET("{malId}", animeHandler::findByMalId)
                 GET("{malId}/update", animeHandler::updateByMalId)
                 POST("{malId}", animeHandler::saveAnime)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
@@ -25,7 +25,7 @@ class RouterConfiguration {
         router {
             "seasons".nest {
                 GET("", animeHandler::getSeasons)
-                GET("{year}/{season}/{page}", animeHandler::searchAnimeBySeason)
+                GET("{year}/{season}", animeHandler::searchAnimeBySeason)
             }
             "/anime".nest {
                 GET("", animeHandler::getAllAnime)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
@@ -26,6 +26,7 @@ enum class LogMessageHandler(val message: String) {
     ANIME_UPDATE_IS_DOWNLOADING("AnimeHandler:updateIsDownloading - Mise à jour de l'état en téléchargement pour l'anime %s"),
     ANIME_SEARCH_BY_SEASON("AnimeHandler:searchAnimeBySeason - Lecture des anime par saison pour l'année %s saison %s"),
     ANIME_GET_SEASONS("AnimeHandler:getSeasons - Lecture de la liste de saisons disponible"),
+    ANIME_GET_RECENT("AnimeHandler:getRecent - Lecture des derniers anime ajouté"),
     ANIME_TORRENT_GET_BY_MAL_ID("AnimeTorrentHandler:getTrackedAnime - Lecture des information de torrent pour l'anime %s"),
     ANIME_TORRENT_GET_ALL("AnimeTorrentHandler:getAllTrackedAnime - Lecture des informations de torrent de tout les animes en cours de téléchargement"),
     ANIME_TORRENT_UPDATE_BY_MAL_ID("AnimeTorrentHandler:updateTrackedAnime - Mise à jour des informations de torrent pour l'anime %s"),

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
@@ -24,7 +24,7 @@ enum class LogMessageHandler(val message: String) {
     ANIME_UPDATE_LAST_AVAIBLE_EPISODE("AnimeHandler:updateLastAvaibleEpisode - Mise à jour du dernier épisode disponible pour l'anime %s"),
     ANIME_UPDATE_IS_COMPLETE("AnimeHandler:updateIsComplete - Mise à jour de l'état complet pour l'anime %s"),
     ANIME_UPDATE_IS_DOWNLOADING("AnimeHandler:updateIsDownloading - Mise à jour de l'état en téléchargement pour l'anime %s"),
-    ANIME_SEARCH_BY_SEASON("AnimeHandler:searchAnimeBySeason - Lecture des anime par saison pour l'année %s saison %s page %s"),
+    ANIME_SEARCH_BY_SEASON("AnimeHandler:searchAnimeBySeason - Lecture des anime par saison pour l'année %s saison %s"),
     ANIME_GET_SEASONS("AnimeHandler:getSeasons - Lecture de la liste de saisons disponible"),
     ANIME_TORRENT_GET_BY_MAL_ID("AnimeTorrentHandler:getTrackedAnime - Lecture des information de torrent pour l'anime %s"),
     ANIME_TORRENT_GET_ALL("AnimeTorrentHandler:getAllTrackedAnime - Lecture des informations de torrent de tout les animes en cours de téléchargement"),

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/RequestType.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/RequestType.kt
@@ -2,6 +2,5 @@ package fr.zakaoai.coldlibrarybackend.enums
 
 enum class RequestType(val type: String) {
     MOVE_TO_SERVER("MOVE_TO_SERVER"),
-    ADD_TO_SERVER("MOVE_TO_SERVER")
-
+    ADD_TO_SERVER("ADD_TO_SERVER")
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
@@ -9,6 +9,8 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.core.util.function.*
+import kotlin.jvm.optionals.getOrNull
 
 @Component
 class AnimeHandler(val animeService: AnimeService) : HandlerUtils() {
@@ -77,9 +79,10 @@ class AnimeHandler(val animeService: AnimeService) : HandlerUtils() {
 
 
     fun searchAnime(req: ServerRequest): Mono<ServerResponse> = req.pathVariable("search").takeIf { it.length >= 3 }
-        .toMono()
-        .flatMapMany(animeService::searchAnime)
-        .collectList()
+        .toMono().zipWith(req.queryParam("page").getOrNull().toMono()
+            .map(String::toInt)
+            .defaultIfEmpty(1))
+        .flatMap {(search, page) -> animeService.searchAnime(search, page) }
         .doOnNext {
             logRequest(
                 req,

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
@@ -177,4 +177,16 @@ class AnimeHandler(val animeService: AnimeService) : HandlerUtils() {
         }
         .flatMap(ServerResponse.ok()::bodyValue)
         .switchIfEmpty(ServerResponse.notFound().build())
+
+    fun getRecent(req: ServerRequest): Mono<ServerResponse> = animeService.getRecent()
+        .collectList()
+        .doOnNext {
+            logRequest(
+                req,
+                LogMessageHandler.ANIME_GET_RECENT.message
+            )
+        }
+        .flatMap(ServerResponse.ok()::bodyValue)
+        .switchIfEmpty(ServerResponse.notFound().build())
+
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/AnimeHandler.kt
@@ -152,8 +152,7 @@ class AnimeHandler(val animeService: AnimeService) : HandlerUtils() {
     fun searchAnimeBySeason(req: ServerRequest): Mono<ServerResponse> =
         animeService.searchAnimeBySeason(
             req.pathVariable("year").toInt(),
-            Season.valueOf(req.pathVariable("season")),
-            req.pathVariable("page").toInt()
+            Season.valueOf(req.pathVariable("season"))
         )
             .collectList()
             .doOnNext {
@@ -161,8 +160,7 @@ class AnimeHandler(val animeService: AnimeService) : HandlerUtils() {
                     req,
                     LogMessageHandler.ANIME_SEARCH_BY_SEASON.message.format(
                         req.pathVariable("year").toInt(),
-                        Season.valueOf(req.pathVariable("season")),
-                        req.pathVariable("page").toInt()
+                        Season.valueOf(req.pathVariable("season"))
                     )
                 )
             }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/JikanApiService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/JikanApiService.kt
@@ -1,5 +1,6 @@
 package fr.zakaoai.coldlibrarybackend.infrastructure
 
+import net.sandrohc.jikan.model.DataListHolderWithPagination
 import net.sandrohc.jikan.model.anime.Anime
 import net.sandrohc.jikan.model.anime.AnimeEpisode
 import net.sandrohc.jikan.model.season.Season
@@ -8,7 +9,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 interface JikanApiService {
-    fun searchAnime(search: String): Flux<Anime>
+    fun searchAnime(search: String, page: Int): Mono<DataListHolderWithPagination<Anime>>
 
     fun getAnimeById(id: Long): Mono<Anime>
 

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/db/services/RequestRepository.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/db/services/RequestRepository.kt
@@ -12,7 +12,7 @@ interface RequestRepository : ReactiveCrudRepository<Request, Long> {
 
     companion object {
         const val getWithInformation: String =
-            "SELECT r.*, creator.name as \"creator\", assignedUser.name as \"assigned_user\", anime.title as \"anime_title\"  FROM cold_library.\"Request\" r INNER JOIN cold_library.\"User\" creator ON r.user_id = creator.user_id LEFT JOIN cold_library.\"User\" assignedUser ON r.assigned_user_id = assignedUser.user_id INNER JOIN cold_library.\"Anime\" anime on r.mal_id = anime.mal_id"
+            "SELECT r.*, creator.name as \"creator\", assignedUser.name as \"assigned_user\", anime.title as \"anime_title\", anime.mal_img as \"mal_img\"  FROM cold_library.\"Request\" r INNER JOIN cold_library.\"User\" creator ON r.user_id = creator.user_id LEFT JOIN cold_library.\"User\" assignedUser ON r.assigned_user_id = assignedUser.user_id INNER JOIN cold_library.\"Anime\" anime on r.mal_id = anime.mal_id"
     }
 
     @Query("$getWithInformation WHERE r.user_id = :creatorId")

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/JikanAPIServiceImpl.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/JikanAPIServiceImpl.kt
@@ -18,11 +18,12 @@ import reactor.core.publisher.Mono
 class JikanAPIServiceImpl(private val jikan: Jikan) : JikanApiService {
 
     @Cacheable(cacheNames = ["jikanAnimes"], unless = "#result instanceof T(java.lang.Exception)")
-    override fun searchAnime(search: String) = jikan.query()
+    override fun searchAnime(search: String, page: Int) = jikan.query()
         .anime()
         .search()
+        .page(page)
         .query(search)
-        .execute()
+        .executeWithoutProcess()
         .cache()
 
     @Cacheable("jikanAnimes")

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/MyAnimeListClientImpl.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/MyAnimeListClientImpl.kt
@@ -49,7 +49,7 @@ class MyAnimeListClientImpl(@Qualifier("MALWebClient") private val webClient: We
                     .queryParam("limit", "1000")
                     .queryParam(
                         "fields",
-                        "start_date,end_date,mean,rank,popularity,nsfw,genres,media_type,status,num_episodes,start_season,broadcast,rating"
+                        "start_date,end_date,mean,rank,popularity,nsfw,genres,media_type,status,num_episodes,start_season,broadcast,rating,num_list_users"
                     )
                     .queryParam("nsfw", "true")
                     .build(year, season)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/MyAnimeListClientImpl.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/implementation/MyAnimeListClientImpl.kt
@@ -46,13 +46,13 @@ class MyAnimeListClientImpl(@Qualifier("MALWebClient") private val webClient: We
         webClient.get()
             .uri {
                 it.path("/v2/anime/season/{year}/{season}")
-                    .queryParam("limit", "1000")
+                    .queryParam("limit", "500")
                     .queryParam(
                         "fields",
                         "start_date,end_date,mean,rank,popularity,nsfw,genres,media_type,status,num_episodes,start_season,broadcast,rating,num_list_users"
                     )
                     .queryParam("nsfw", "true")
-                    .build(year, season)
+                    .build(year, season.search)
             }
             .retrieve()
             .bodyToMono(MALAnimeListResponse::class.java)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/model/myanimelist/MALAnimeListNode.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/model/myanimelist/MALAnimeListNode.kt
@@ -10,7 +10,7 @@ data class MALAnimeListNode(
     val mean: Float?,
     val rank: Int?,
     val popularity: Int?,
-    val genres: List<MALGenre>,
+    val genres: List<MALGenre>?,
     val media_type: String,
     val status: String,
     val num_episodes: Int,

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/model/myanimelist/MALAnimeListNode.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/infrastructure/model/myanimelist/MALAnimeListNode.kt
@@ -17,6 +17,6 @@ data class MALAnimeListNode(
     val start_season: MALSeason?,
     val broadcast: MALBroadcast?,
     val rating: String?,
-    val userStatus: String?
-
+    val userStatus: String?,
+    val num_list_users: Int?
 )

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/model/dto/response/RequestDTO.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/model/dto/response/RequestDTO.kt
@@ -9,6 +9,7 @@ data class RequestDTO(
     val id: Long,
     val malId: Long,
     val animeTitle: String,
+    var malImg: String?,
     val type: RequestType,
     val state: RequestStatus,
     val date: LocalDateTime,

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/model/mapper/RequestDAOMapper.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/model/mapper/RequestDAOMapper.kt
@@ -1,9 +1,0 @@
-package fr.zakaoai.coldlibrarybackend.model.mapper
-
-import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.Anime
-import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.Request
-import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.User
-import fr.zakaoai.coldlibrarybackend.model.dto.response.RequestDTO
-
-fun Request.toRequestDTO(anime: Anime, creator: User, assignedUser: User?) =
-    RequestDTO(id!!, malId, anime.title, type, state, date, creator.name, assignedUser?.name)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeEpisodeTorrentService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeEpisodeTorrentService.kt
@@ -43,9 +43,13 @@ class AnimeEpisodeTorrentService(
             .flatMapMany { animeEpisodeTorrent ->
                 animeTorrentRepository.findById(malId)
                     .flatMapMany {
+                        var episodeToSearch = episodeNumber + it.deltaEpisode
+                        if(episodeNumber == 0) {
+                            episodeToSearch = 0
+                        }
                         nyaaTorrentService.searchEpisodeTorrent(
                             malId,
-                            episodeNumber + it.deltaEpisode,
+                            episodeToSearch,
                             it.searchWords
                         )
                     }
@@ -126,7 +130,17 @@ class AnimeEpisodeTorrentService(
             .flatMapMany {
                 if (it.isEmpty)
                     animeTorrentRepository.findById(malId)
-                        .flatMapMany { nyaaTorrentService.searchEpisodeTorrent(malId, episodeNumber + it.deltaEpisode, it.searchWords) }
+                        .flatMapMany {
+                            var episodeToSearch = episodeNumber + it.deltaEpisode
+                            if(episodeNumber == 0) {
+                                episodeToSearch = 0
+                            }
+                            nyaaTorrentService.searchEpisodeTorrent(
+                                malId,
+                                episodeToSearch,
+                                it.searchWords
+                            )
+                        }
                 else
                     Flux.empty()
             }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
@@ -12,10 +12,12 @@ import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeTorrentRepo
 import fr.zakaoai.coldlibrarybackend.model.dto.response.AnimeInServerDTO
 import fr.zakaoai.coldlibrarybackend.model.dto.response.AnimeWithServerInformationDTO
 import fr.zakaoai.coldlibrarybackend.model.mapper.*
+import net.sandrohc.jikan.model.DataListHolderWithPagination
 import net.sandrohc.jikan.model.season.Season
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toFlux
 import java.time.DayOfWeek
 import net.sandrohc.jikan.model.anime.Anime as JikanAnime
 
@@ -56,11 +58,21 @@ class AnimeService(
     fun findByMalId(id: Long): Mono<AnimeWithServerInformationDTO> =
         animeInServerRepository.findWithAnimeInformation(id)
 
-    fun searchAnime(search: String): Flux<AnimeWithServerInformationDTO> = jikanService.searchAnime(search)
-        .flatMap { jikanAnime ->
-            findByMalId(jikanAnime.malId.toLong())
-                .defaultIfEmpty(jikanAnime.toAnimeWithServerInformationDTO())
-        }
+    fun searchAnime(search: String, page: Int): Mono<DataListHolderWithPagination<AnimeWithServerInformationDTO>> =
+        jikanService.searchAnime(search, page)
+            .flatMap { datalistwithPagination ->
+                datalistwithPagination.data.toFlux()
+                    .flatMap { jikanAnime -> findByMalId(jikanAnime.malId.toLong()).defaultIfEmpty(jikanAnime.toAnimeWithServerInformationDTO()) }
+                    .collectList()
+                    .map {
+                        val result = DataListHolderWithPagination<AnimeWithServerInformationDTO>()
+                        result.setPagination(datalistwithPagination.pagination)
+                        result.setData(
+                            it
+                        )
+                        result
+                    }
+            }
 
     fun updateAnimeStorageState(
         malId: Long,

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
@@ -3,12 +3,14 @@ package fr.zakaoai.coldlibrarybackend.service
 
 import fr.zakaoai.coldlibrarybackend.enums.StorageState
 import fr.zakaoai.coldlibrarybackend.infrastructure.JikanApiService
+import fr.zakaoai.coldlibrarybackend.infrastructure.MyAnimeListClient
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.Anime
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.AnimeInServer
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.entities.AnimeTorrent
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeInServerRepository
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeRepository
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeTorrentRepository
+import fr.zakaoai.coldlibrarybackend.infrastructure.model.myanimelist.MALAnimeListData
 import fr.zakaoai.coldlibrarybackend.model.dto.response.AnimeInServerDTO
 import fr.zakaoai.coldlibrarybackend.model.dto.response.AnimeWithServerInformationDTO
 import fr.zakaoai.coldlibrarybackend.model.mapper.*
@@ -27,7 +29,8 @@ class AnimeService(
     private val animeInServerRepository: AnimeInServerRepository,
     private val animeRepository: AnimeRepository,
     private val jikanService: JikanApiService,
-    private val animeTorrentRepository: AnimeTorrentRepository
+    private val animeTorrentRepository: AnimeTorrentRepository,
+    val myAnimeListClient: MyAnimeListClient
 ) {
 
     fun getAllAnime(): Flux<AnimeWithServerInformationDTO> = animeInServerRepository.findAllWithAnimeInformation()
@@ -114,11 +117,8 @@ class AnimeService(
             .flatMap(animeInServerRepository::save)
             .map(AnimeInServer::toAnimeInServerDTO)
 
-    fun searchAnimeBySeason(year: Int, season: Season, page: Int) = jikanService.getAnimeBySeason(year, season, page)
-        .flatMap { jikanAnime ->
-            findByMalId(jikanAnime.malId.toLong())
-                .defaultIfEmpty(jikanAnime.toAnimeWithServerInformationDTO())
-        }
+    fun searchAnimeBySeason(year: Int, season: Season) = myAnimeListClient.getAnimeSeason(year, season).flatMapMany { it.data.map(MALAnimeListData::node).toFlux() }
+
 
     fun getSeasons() = jikanService.getSeason()
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeService.kt
@@ -121,4 +121,9 @@ class AnimeService(
 
 
     fun getSeasons() = jikanService.getSeason()
+
+    fun getRecent() = animeInServerRepository.findAllWithAnimeInformation()
+        .filter{ it.storageState === StorageState.FLUX_CHAUD}
+        .sort(compareBy<AnimeWithServerInformationDTO> { it.addedOnServer}.reversed() )
+        .take(5)
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ auth0:
     audience: https://zakaoai.eu.auth0.com/api/v2/
 
 spring:
+  jackson:
+    default-property-inclusion: non_null
   codec:
     max-in-memory-size: 500KB
   security:

--- a/src/test/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeServiceTest.kt
+++ b/src/test/kotlin/fr/zakaoai/coldlibrarybackend/service/AnimeServiceTest.kt
@@ -2,6 +2,7 @@ package fr.zakaoai.coldlibrarybackend.service
 
 
 import fr.zakaoai.coldlibrarybackend.infrastructure.JikanApiService
+import fr.zakaoai.coldlibrarybackend.infrastructure.MyAnimeListClient
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeInServerRepository
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeRepository
 import fr.zakaoai.coldlibrarybackend.infrastructure.db.services.AnimeTorrentRepository
@@ -29,6 +30,9 @@ class AnimeServiceTest {
     @MockK
     lateinit var jikanService: JikanApiService
 
+    @MockK
+    lateinit var myAnimeListClient: MyAnimeListClient
+
     @InjectMockKs
     lateinit var animeService: AnimeService
 
@@ -36,7 +40,7 @@ class AnimeServiceTest {
     fun setUp() = MockKAnnotations.init(this)
 
     @Test
-    fun getListRdq_shouldReturnEmptyList_WhenRdqRepositoryReturnEmptyList() {
+    fun getExemple() {
 
         every { animeInServerRepository.findAllWithAnimeInformation() } returns Flux.empty()
 


### PR DESCRIPTION
Ajoute un endpoint pour récupérer les animes ajoutés récemment.

- Utilise l'API Season de MAL pour récupérer les informations.
- Affiche le nombre d'utilisateurs qui ont l'anime dans leur liste.
- Ajoute la pagination à la recherche d'anime.