### PR TITLE
⬆️ Met à niveau Gradle vers la version 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.4.0-jdk17-alpine AS cache
+FROM gradle:9-jdk17-alpine AS cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle.kts /home/gradle/java-code/
@@ -6,7 +6,7 @@ COPY settings.gradle.kts /home/gradle/java-code/
 WORKDIR /home/gradle/java-code
 RUN gradle clean build -i --stacktrace -x bootJar
 
-FROM gradle:8.4.0-jdk17-alpine AS build
+FROM gradle:9-jdk17-alpine AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src


### PR DESCRIPTION
Mise à jour de l'image Docker pour utiliser Gradle 9,
tirant parti des dernières améliorations et corrections.

Cela garantit que les builds utilisent les versions les
plus récentes des dépendances et des outils.
