### PR TITLE
feat: Autorise la suppression de requêtes.

### DIFF
--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/config/RouterConfiguration.kt
@@ -82,6 +82,7 @@ class RouterConfiguration {
                 GET("assigned", requestHandler::getMyAssignedRequest)
                 GET("all", requestHandler::getAllRequest)
                 POST("{requestId}", requestHandler::updateRequest)
+                DELETE("{requestId}", requestHandler::deleteRequest)
             }
             "log".nest {
                 GET("", logHandler::getAllLogs)

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/enums/LogMessageHandler.kt
@@ -45,6 +45,9 @@ enum class LogMessageHandler(val message: String) {
     REQUEST_GET_MY_ASSIGNED("RequestHandler:getMyAssignedRequest - Lecture des requêtes assigné à l'utlisateur"),
     REQUEST_GET_ALL("RequestHandler:getAllRequest - Lecture de toute les requests"),
     REQUEST_UPDATE("RequestHandler:updateRequest - Mise à jour de la request %s"),
+    REQUEST_DELETE("RequestHandler:deleteRequest - Suppression de la request %s"),
+
+    REQUEST_DELETE_ILLEGAL_ACCESS("RequestHandler:deleteRequest - Tentative de suppression de la request %s sans autorisation"),
     USER_CURRENT("UserHandler:getCurrentUser - Lecture des informations courante de l'utlilisateur"),
     USER_UPDATE_CURRENT_MAL_USERNAME("UserHandler:updateCurrentUserMalUsername - Mise à jour du nom d'utilisateur MyAnimeList pour l'utilisateur courrant"),
     USER_GET_ALL("UserHandler:getAllUser - Lecture de tout les utilisateurs"),

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/RequestHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/RequestHandler.kt
@@ -6,6 +6,7 @@ import fr.zakaoai.coldlibrarybackend.service.RequestService
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
+import java.lang.IllegalAccessException
 
 @Component
 class RequestHandler(val requestService: RequestService) : HandlerUtils() {
@@ -65,4 +66,27 @@ class RequestHandler(val requestService: RequestService) : HandlerUtils() {
             )
         }
         .flatMap(ServerResponse.ok()::bodyValue)
+
+    fun deleteRequest(req: ServerRequest) =
+        requestService.deleteRequest(req.pathVariable("requestId").toLong())
+            .doOnNext {
+                logRequest(
+                    req,
+                    LogMessageHandler.REQUEST_DELETE.message.format(
+                        req.pathVariable("requestId").toLong()
+                    )
+                )
+            }
+            .flatMap { ServerResponse.ok().build() }
+            .doOnError( IllegalAccessException::class.java) {
+                logRequest(
+                    req,
+                    LogMessageHandler.REQUEST_DELETE_ILLEGAL_ACCESS.message.format(
+                        req.pathVariable("requestId").toLong()
+                    )
+                )
+            }
+            .onErrorResume( IllegalAccessException::class.java) {
+                ServerResponse.status(403).bodyValue(mapOf("error" to (it.message ?: "Forbidden")))
+            }
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/RequestHandler.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/handler/RequestHandler.kt
@@ -87,6 +87,6 @@ class RequestHandler(val requestService: RequestService) : HandlerUtils() {
                 )
             }
             .onErrorResume( IllegalAccessException::class.java) {
-                ServerResponse.status(403).bodyValue(mapOf("error" to (it.message ?: "Forbidden")))
+                ServerResponse.status(412).bodyValue(mapOf("error" to (it.message ?: "Forbidden")))
             }
 }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/RequestService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/RequestService.kt
@@ -51,7 +51,7 @@ class RequestService(
         .map(SecurityContext::getAuthentication)
         .map { Pair(it.name,it.authorities) }
         .flatMap { p -> requestRepository.findById(requestId)
-            .filter { request -> request.userId === p.first || p.second.any { it.authority == "admin" }}
+            .filter { request -> request.userId == p.first || p.second.any { it.authority == "admin" }}
         }
         .switchIfEmpty(Mono.error(IllegalAccessException("Vous n'êtes pas autorisé à supprimer cette demande")))
         .flatMap { requestRepository.deleteById(it.id!!) }

--- a/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/RequestService.kt
+++ b/src/main/kotlin/fr/zakaoai/coldlibrarybackend/service/RequestService.kt
@@ -7,6 +7,9 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import reactor.util.function.Tuple2
 
 @Service
 class RequestService(
@@ -43,5 +46,14 @@ class RequestService(
     }
         .flatMap(requestRepository::save)
         .then(requestRepository.findByIdWithInformation(requestId))
+
+    fun deleteRequest(requestId: Long) = ReactiveSecurityContextHolder.getContext()
+        .map(SecurityContext::getAuthentication)
+        .map { Pair(it.name,it.authorities) }
+        .flatMap { p -> requestRepository.findById(requestId)
+            .filter { request -> request.userId === p.first || p.second.any { it.authority == "admin" }}
+        }
+        .switchIfEmpty(Mono.error(IllegalAccessException("Vous n'êtes pas autorisé à supprimer cette demande")))
+        .flatMap { requestRepository.deleteById(it.id!!) }
 
 }


### PR DESCRIPTION
Cette PR introduit la fonctionnalité de suppression des requêtes et corrige un problème d'autorisation. Il ajoute un point de terminaison pour la suppression et met en œuvre une vérification des autorisations.

# Changes
* Ajout d'un point de terminaison DELETE "/{requestId}" dans RouterConfiguration.kt pour la suppression des requêtes.
* Implémentation de la fonction deleteRequest dans RequestHandler.kt qui appelle le service RequestService pour effectuer la suppression.
* Ajout de la gestion des erreurs et des logs dans RequestHandler.kt pour la suppression de requêtes, y compris la gestion des accès non autorisés.
Implémentation de la fonction deleteRequest dans RequestService.kt qui vérifie si l'utilisateur courant a la permission de supprimer la requête (soit l'auteur, soit un admin).
* Ajout de nouvelles entrées de log dans LogMessageHandler.kt pour la suppression de requêtes, ainsi que pour les tentatives de suppression non autorisées.

# Impact
* Les utilisateurs peuvent maintenant supprimer les requêtes via une requête DELETE.
* La suppression est soumise à une vérification d'autorisation, empêchant les utilisateurs non autorisés de supprimer les requêtes d'autres personnes.
Amélioration de la traçabilité grâce à l'ajout de logs pour les suppressions de requêtes et les tentatives d'accès non autorisées.